### PR TITLE
#15

### DIFF
--- a/include/mpi_openmp_kmer_counter.hpp
+++ b/include/mpi_openmp_kmer_counter.hpp
@@ -1,4 +1,6 @@
-#pragma once
+#ifndef MPI_OPENMP_KMER_COUNTER_HPP
+#define MPI_OPENMP_KMER_COUNTER_HPP
+
 #include <unordered_map>
 #include <string>
 #include <chrono>
@@ -13,3 +15,5 @@ void merge_maps(std::unordered_map<std::string, int>& target, const std::unorder
 std::pair<std::vector<char>, std::vector<int> > serialize_map(const std::unordered_map<std::string, int>& map);
 std::unordered_map<std::string, int> deserialize_map(const std::vector<char>& flattened_kmers, const std::vector<int> kmer_counts, const int& k);
 std::unordered_map<std::string, int> count_kmers(const std::string& fasta_filepath, const int& k);
+
+#endif

--- a/include/naive_kmer_counter.hpp
+++ b/include/naive_kmer_counter.hpp
@@ -1,5 +1,9 @@
-#pragma once
+#ifndef NAIVE_KMER_COUNTER_HPP
+#define NAIVE_KMER_COUNTER_HPP
+
 #include <string>
 #include <unordered_map>
 
-std::unordered_map<std::string, int> count_kmers(const std::string& sequence, int k);
+std::unordered_map<std::string, int> count_kmers(const std::string& sequence, const int& k);
+
+#endif

--- a/include/openmp_kmer_counter.hpp
+++ b/include/openmp_kmer_counter.hpp
@@ -1,4 +1,6 @@
-#pragma once
+#ifndef OPENMP_KMER_COUNTER_HPP
+#define OPENMP_KMER_COUNTER_HPP
+
 #include <unordered_map>
 #include <fstream>
 #include <string>
@@ -7,4 +9,6 @@
 #include <omp.h>
 #include <vector>
 
-std::unordered_map<std::string, int> count_kmers(const std::string& sequence, int k);
+std::unordered_map<std::string, int> count_kmers(const std::string& sequence, const int& k);
+
+#endif

--- a/include/utils.hpp
+++ b/include/utils.hpp
@@ -2,3 +2,4 @@
 #include <fstream>
 
 std::string read_fasta(const std::string& fasta_filepath);
+void check_edge_cases(const std::string& sequence, const int& k);

--- a/include/utils.hpp
+++ b/include/utils.hpp
@@ -1,5 +1,10 @@
+#ifndef UTILS_HPP
+#define UTILS_HPP
+
 #include <string>
 #include <fstream>
 
 std::string read_fasta(const std::string& fasta_filepath);
 void check_edge_cases(const std::string& sequence, const int& k);
+
+#endif

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -15,6 +15,7 @@ int main(int argc, char* argv[]) {
     auto start = std::chrono::high_resolution_clock::now();
 
     std::string sequence = read_fasta(filepath);
+    check_edge_cases(sequence, k);
     auto kmer_counts = count_kmers(sequence, k);
 
     auto end = std::chrono::high_resolution_clock::now();

--- a/src/mpi_openmp_kmer_counter.cpp
+++ b/src/mpi_openmp_kmer_counter.cpp
@@ -1,5 +1,8 @@
-#include <mpi_openmp_kmer_counter.hpp>
-#include <utils.hpp>
+#include "mpi_openmp_kmer_counter.hpp"
+#include "utils.hpp"
+
+// mpic++ -fopenmp -Iinclude src/mpi_openmp_kmer_counter.cpp -o mpi_openmp_kmer_counter
+// mpiexec -n 1 ./mpi_openmp_kmer_counter
 
 bool run_mpi_init() {
     bool i_initialized_mpi = false;
@@ -21,8 +24,9 @@ void run_mpi_finalize(bool mpi_init_ran) {
 }
 
 // Openmp portion inside of each rank
-std::unordered_map<std::string, int> omp_count_kmers(const std::string& sequence, int k) {
-    int num_threads = omp_get_max_threads();
+std::unordered_map<std::string, int> omp_count_kmers(std::string& sequence, const int& k) {
+    int num_threads = std::min(omp_get_max_threads(), int(sequence.size()));
+
     std::vector<std::unordered_map<std::string, int> > thread_maps(num_threads);
     #pragma omp parallel
     {
@@ -42,12 +46,16 @@ std::unordered_map<std::string, int> omp_count_kmers(const std::string& sequence
             merged_maps[kmer.first] += kmer.second;
         }
     }
+
     return merged_maps;
 }
 
 void merge_maps(std::unordered_map<std::string, int>& target, const std::unordered_map<std::string, int>& source) {
     for (const auto& p: source) {
         target[p.first] += p.second;
+        #ifdef DEBUG_MODE
+            std::cout << "Rank: " << rank << p.first << ": " << p.second << std::endl;
+        #endif
     }
 }
 
@@ -67,9 +75,12 @@ std::pair<std::vector<char>, std::vector<int> > serialize_map(const std::unorder
 std::unordered_map<std::string, int> deserialize_map(const std::vector<char>& flattened_kmers, const std::vector<int> kmer_counts, const int& k) {
     int num_threads = omp_get_max_threads();
     std::vector<std::unordered_map<std::string, int> > thread_maps(num_threads);
+
     #pragma omp parallel
     {
         int tid = omp_get_thread_num();
+
+        #pragma omp for
         for (int i = 0; i < kmer_counts.size(); i++) {
             std::string kmer(flattened_kmers.begin() + i * k, flattened_kmers.begin() + (i + 1) * k);
             thread_maps[tid][kmer] += kmer_counts.at(i);
@@ -83,12 +94,17 @@ std::unordered_map<std::string, int> deserialize_map(const std::vector<char>& fl
             merged_map[kmer.first] += kmer.second;
         }
     }
+    #ifdef DEBUG_MODE
+    for (auto& map : merged_map) {
+        std::cout << map.first << ": " << map.second << std::endl;
+    }
+    #endif
 
     return merged_map;
 }
 
 std::unordered_map<std::string, int> count_kmers(const std::string& sequence, const int& k) {
-    check_edge_cases(sequence, k);
+    // check_edge_cases(sequence, k);
 
     bool check_mpi_init = run_mpi_init();
 
@@ -99,16 +115,53 @@ std::unordered_map<std::string, int> count_kmers(const std::string& sequence, co
     int sequence_size = sequence.size();
 
     int base_chunk_size = sequence.size() / size;
-    int starting_index = base_chunk_size * rank;
-    int ending_index = base_chunk_size * (rank + 1) - 1;
+    int leftovers = sequence_size % size;
 
-    int ghost_left = (rank == 0) ? 0 : (k - 1);
+    #ifdef DEBUG_MODE
+    std::cout << "Sequence Size: " << sequence_size << std::endl;
+    std::cout << "Base Chunk Size: " << base_chunk_size << std::endl;
+    std::cout << "Leftovers: " << leftovers << std::endl;
+    #endif
+
+    int starting_index = base_chunk_size * rank + std::min(rank, leftovers);
+    int ending_index = starting_index + base_chunk_size - 1;
+    if (rank < leftovers) {ending_index++;}
+
+    #ifdef DEBUG_MODE
+    std::cout << rank << " starting index: " << starting_index << std::endl;
+    std::cout << rank << " ending index: " << ending_index << std::endl;
+    #endif
+
+    int ghost_left = 0; //(rank == 0) ? 0 : (k - 1);
     int ghost_right = (rank == size - 1) ? 0 : (k - 1);
 
     int local_start = std::max(0, starting_index - ghost_left);
-    int local_end = std::min(sequence_size ,ending_index + ghost_right);
+    int local_end = std::min(sequence_size, ending_index + ghost_right);
 
-    std::string local_sequence = sequence.substr(local_start, local_end - local_start);
+    #ifdef DEBUG_MODE
+    std::cout << rank << " local start index: " << local_start << std::endl;
+    std::cout << rank << " local end index: " << local_end << std::endl;
+    #endif
+
+
+    // REMOVE AFTER PASSING EXTENSIVE TESTING
+    // int local_length = std::max(0, local_end - local_start + 1);
+    // if (local_start + local_length > sequence_size) {
+    //     local_length = sequence_size - local_start;
+    // }
+
+    // REMOVE AFTER PASSING EXTENSIVE TESTING
+    // std::string local_sequence = sequence.substr(local_start, local_length);
+    std::string local_sequence = sequence.substr(local_start, std::min(sequence_size, local_end - local_start + 1));
+
+    int valid_start = starting_index - local_start;
+    int valid_end = ending_index - local_start;
+
+    #ifdef DEBUG_MODE
+    std::cout << local_sequence << std::endl;
+    std::cout << rank << "valid start: " << valid_start << std::endl;
+    std::cout << rank << "valid end: " << valid_end << std::endl;
+    #endif
 
     // Each rank has their own local map
     std::unordered_map<std::string, int> local_map = omp_count_kmers(local_sequence, k);
@@ -155,7 +208,19 @@ std::unordered_map<std::string, int> count_kmers(const std::string& sequence, co
         global_kmer_map = deserialize_map(global_flattened_kmers, global_kmer_counts, k);
     }
 
+    #ifdef DEBUG_MODE
+    for (auto& kmer : global_kmer_map) {
+        std::cout <<kmer.first << " = " << kmer.second << std::endl;
+    }
+    #endif
+
+    MPI_Barrier(MPI_COMM_WORLD);
+
     run_mpi_finalize(check_mpi_init);
 
-    return global_kmer_map;
+    if (rank == 0) {
+        return global_kmer_map;
+    } else{
+        return {};
+    }
 }

--- a/src/mpi_openmp_kmer_counter.cpp
+++ b/src/mpi_openmp_kmer_counter.cpp
@@ -1,4 +1,5 @@
 #include <mpi_openmp_kmer_counter.hpp>
+#include <utils.hpp>
 
 bool run_mpi_init() {
     bool i_initialized_mpi = false;
@@ -87,6 +88,8 @@ std::unordered_map<std::string, int> deserialize_map(const std::vector<char>& fl
 }
 
 std::unordered_map<std::string, int> count_kmers(const std::string& sequence, const int& k) {
+    check_edge_cases(sequence, k);
+
     bool check_mpi_init = run_mpi_init();
 
     int rank, size;

--- a/src/naive_kmer_counter.cpp
+++ b/src/naive_kmer_counter.cpp
@@ -1,6 +1,8 @@
 #include <naive_kmer_counter.hpp>
+#include <utils.hpp>
 
-std::unordered_map<std::string, int> count_kmers(const std::string& sequence, int k) {
+std::unordered_map<std::string, int> count_kmers(const std::string& sequence, const int& k) {
+    check_edge_cases(sequence, k);
     std::unordered_map<std::string, int> kmer_counts;
     for (int i = 0; i <= static_cast<int>(sequence.size()) - k; i++) {
         std::string kmer = sequence.substr(i, k);

--- a/src/naive_kmer_counter.cpp
+++ b/src/naive_kmer_counter.cpp
@@ -1,8 +1,8 @@
-#include <naive_kmer_counter.hpp>
-#include <utils.hpp>
+#include "naive_kmer_counter.hpp"
+#include "utils.hpp"
 
 std::unordered_map<std::string, int> count_kmers(const std::string& sequence, const int& k) {
-    check_edge_cases(sequence, k);
+    // check_edge_cases(sequence, k);
     std::unordered_map<std::string, int> kmer_counts;
     for (int i = 0; i <= static_cast<int>(sequence.size()) - k; i++) {
         std::string kmer = sequence.substr(i, k);

--- a/src/openmp_kmer_counter.cpp
+++ b/src/openmp_kmer_counter.cpp
@@ -1,6 +1,9 @@
 #include <openmp_kmer_counter.hpp>
+#include <utils.hpp>
 
 std::unordered_map<std::string, int> count_kmers(const std::string& sequence, int k) {
+    check_edge_cases(sequence, k);
+
     int num_threads = omp_get_max_threads();
     std::vector<std::unordered_map<std::string, int> > thread_maps(num_threads);
 

--- a/src/openmp_kmer_counter.cpp
+++ b/src/openmp_kmer_counter.cpp
@@ -1,7 +1,7 @@
-#include <openmp_kmer_counter.hpp>
-#include <utils.hpp>
+#include "openmp_kmer_counter.hpp"
+#include "utils.hpp"
 
-std::unordered_map<std::string, int> count_kmers(const std::string& sequence, int k) {
+std::unordered_map<std::string, int> count_kmers(const std::string& sequence, const int& k) {
     check_edge_cases(sequence, k);
 
     int num_threads = omp_get_max_threads();

--- a/src/utils.cpp
+++ b/src/utils.cpp
@@ -10,3 +10,15 @@ std::string read_fasta(const std::string& fasta_filepath) {
     file.close();
     return sequence;
 }
+
+void check_edge_cases(const std::string& sequence, const int& k) {
+    if (k <= 0) {
+        throw std::runtime_error("K cannot be less than or equal to 0. Please provide a positive integer for k");
+    }
+    if (sequence.empty()) {
+        throw std::runtime_error("Sequence is empty! Ensure Fasta is populated and formatted correctly!");
+    }
+    if (sequence.size() < k) {
+        throw std::runtime_error("Sequence is smaller than k. \nPlease provide a smaller k, check the Fasta formatting, or provide a separate Fasta");
+    }
+}

--- a/src/utils.cpp
+++ b/src/utils.cpp
@@ -1,4 +1,4 @@
-#include <utils.hpp>
+#include "utils.hpp"
 
 std::string read_fasta(const std::string& fasta_filepath) {
     std::ifstream file(fasta_filepath);

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -1,17 +1,17 @@
 find_package(MPI)
 find_package(OpenMP)
 
-add_executable(kmer_naive_tests test_naive.cpp ${PROJECT_SOURCE_DIR}/src/naive_kmer_counter.cpp)
+add_executable(kmer_naive_tests test_naive.cpp)
 target_include_directories(kmer_naive_tests PRIVATE ${PROJECT_SOURCE_DIR}/include)
-target_link_libraries(kmer_naive_tests PRIVATE gtest gtest_main)
+target_link_libraries(kmer_naive_tests PRIVATE gtest gtest_main naive_kmer_counter)
 add_test(NAME kmer_naive_tests COMMAND kmer_naive_tests)
 
-add_executable(kmer_openmp_tests test_openmp.cpp ${PROJECT_SOURCE_DIR}/src/openmp_kmer_counter.cpp)
+add_executable(kmer_openmp_tests test_openmp.cpp)
 target_include_directories(kmer_openmp_tests PRIVATE ${PROJECT_SOURCE_DIR}/include)
-target_link_libraries(kmer_openmp_tests PRIVATE gtest gtest_main OpenMP::OpenMP_CXX)
+target_link_libraries(kmer_openmp_tests PRIVATE gtest gtest_main openmp_kmer_counter OpenMP::OpenMP_CXX )
 add_test(NAME kmer_openmp_tests COMMAND kmer_openmp_tests)
 
-add_executable(kmer_mpi_openmp_tests test_mpi.cpp ${PROJECT_SOURCE_DIR}/src/mpi_openmp_kmer_counter.cpp)
+add_executable(kmer_mpi_openmp_tests test_mpi.cpp)
 target_include_directories(kmer_mpi_openmp_tests PRIVATE ${PROJECT_SOURCE_DIR}/include)
-target_link_libraries(kmer_mpi_openmp_tests PRIVATE gtest gtest_main OpenMP::OpenMP_CXX MPI::MPI_CXX)
+target_link_libraries(kmer_mpi_openmp_tests PRIVATE gtest gtest_main mpi_openmp_kmer_counter OpenMP::OpenMP_CXX MPI::MPI_CXX )
 add_test(NAME kmer_mpi_openmp_tests COMMAND ${MPIEXEC_EXECUTABLE} ${MPIEXEC_NUMPROC_FLAG} 2 ./kmer_mpi_openmp_tests)

--- a/tests/test_naive.cpp
+++ b/tests/test_naive.cpp
@@ -1,7 +1,7 @@
 #include <string>
 #include <unordered_map>
 #include <gtest/gtest.h>
-#include "naive_kmer_counter.hpp"
+#include <naive_kmer_counter.hpp>
 
 
 static std::string simple_sequence = "ABCDEFG";


### PR DESCRIPTION
Closes #15 
Fixed MPI implementation:
- Ghost left removed, not needed for kmer counter
- OMP threads fixed in deserialize map
- CMakefiles.txt in tests directory changed
- Added safer linking with ifndef/defines

Passes google tests!